### PR TITLE
Fix travis.ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - ruby-1.9.3
+  - ruby-2.2.1
 script:
   - bundle exec rake test_app
   - bundle exec rspec .


### PR DESCRIPTION
Noticed that tests weren't run because of a gem couldn't be installed on ruby 1.9 and decided to update ruby version in travis.yml. Some of the tests are failing but I think it's better to have failing tests than a broken build